### PR TITLE
Update paypalr.css

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/paypalr.css
+++ b/includes/modules/payment/paypal/PayPalRestful/paypalr.css
@@ -35,7 +35,7 @@
     cursor: pointer;
     height: 2.5rem;
     font-weight: bold;
-    width: 11rem;
+    width: fit-content;
     display: inline-block;
     text-align: center;
 }


### PR DESCRIPTION
The width of 11rem for the .ppr-button-choice label is fine with just three CC options.  Adding another option breaks the display.