### PR TITLE
Update paypalr_bootstrap.css

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/paypalr_bootstrap.css
+++ b/includes/modules/payment/paypal/PayPalRestful/paypalr_bootstrap.css
@@ -32,7 +32,7 @@
     cursor: pointer;
     height: 4rem;
     font-weight: bold;
-    width: 11rem;
+    width: fit-content;
     display: inline-block;
     text-align: center;
 }


### PR DESCRIPTION
The width of 11rem for the .ppr-button-choice label is fine with just three CC options.  Adding another option breaks the display.