### PR TITLE
Transmit billing address to PayPal

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Zc2Pp/ConfirmPayPalPaymentChoiceRequest.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Zc2Pp/ConfirmPayPalPaymentChoiceRequest.php
@@ -6,10 +6,13 @@
  * @copyright Copyright 2023 Zen Cart Development Team
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: lat9 2023 Nov 16 Modified in v2.0.0 $
+ *
+ * Last updated: v1.0.5
  */
 namespace PayPalRestful\Zc2Pp;
 
 use PayPalRestful\Common\Logger;
+use PayPalRestful\Zc2Pp\Address;
 
 class ConfirmPayPalPaymentChoiceRequest
 {
@@ -60,6 +63,7 @@ class ConfirmPayPalPaymentChoiceRequest
                     'surname' => $order->billing['lastname'],
                 ],
                 'email_address' => $order->customer['email_address'],
+                'address' => Address::get($order->billing),
                 'experience_context' => [
                     'payment_method_preference' => 'IMMEDIATE_PAYMENT_REQUIRED',    //- No eChecks, no means to test in the sandbox environment
                     'brand_name' => $brand_name,

--- a/includes/modules/payment/paypalr.php
+++ b/includes/modules/payment/paypalr.php
@@ -1130,7 +1130,6 @@ class paypalr extends base
         //
         $paypal_id = $order_response['id'];
         $status = $order_response['status'];
-        $create_time = $order_response['create_time'];
         unset(
             $order_response['id'],
             $order_response['status'],
@@ -1143,7 +1142,6 @@ class paypalr extends base
             'current' => $order_response,
             'id' => $paypal_id,
             'status' => $status,
-            'create_time' => $create_time,
             'guid' => $order_guid,
             'payment_source' => $ppr_type,
             'amount_mismatch' => $order_amount_mismatch,


### PR DESCRIPTION
... so that if the customer chooses to use a credit-card without using their PayPal account, the billing address reflects that which has been submitted during the checkout process.