### PR TITLE
Code update: call parent constructor from child class

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Api/PayPalRestfulApi.php
@@ -131,6 +131,8 @@ class PayPalRestfulApi extends ErrorInfo
     //
     public function __construct(string $endpoint_type, string $client_id, string $client_secret)
     {
+        parent::__construct();
+
         $this->endpoint = ($endpoint_type === 'live') ? self::ENDPOINT_PRODUCTION : self::ENDPOINT_SANDBOX;
         $this->clientId = $client_id;
         $this->clientSecret = $client_secret;
@@ -592,8 +594,8 @@ class PayPalRestfulApi extends ErrorInfo
             $response = false;
             $this->handleCurlError($request_type, $option, $curl_options);
         // -----
-        // Otherwise, a response was returned.  Call the common response-handler to determine
-        // whether or not an error occurred.
+        // Otherwise, a response was returned.
+        // Call the common response-handler to determine whether or not an error occurred.
         //
         } else {
             $response = $this->handleResponse($request_type, $option, $curl_options, $curl_response);

--- a/includes/modules/payment/paypal/PayPalRestful/Zc2Pp/CreatePayPalOrderRequest.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Zc2Pp/CreatePayPalOrderRequest.php
@@ -69,6 +69,8 @@ class CreatePayPalOrderRequest extends ErrorInfo
     //
     public function __construct(string $ppr_type, \order $order, array $cc_info, array $order_info, array $ot_diffs)
     {
+        parent::__construct();
+
         $this->log = new Logger();
 
         global $currencies;


### PR DESCRIPTION
The parent class does some var/property resets, which we're bypassing when overriding the constructor.
In practice it may be moot such as if we're never "needing" the reset. But unless we intended to skip it, we should call it.


Also reformatted a code comment, for readability.