### PR TITLE
Avoid messageStack conflicts for webhooks

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/Admin/Formatters/NullMessages.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Admin/Formatters/NullMessages.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * A null-object class that simulates messageStack messages triggered by webhooks in code that is shared by the
+ * admin_notifications method of the PayPal Restful payment module.
+ *
+ * @copyright Copyright 2025 Zen Cart Development Team
+ * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: lat9 2023 Nov 16 Modified in v2.0.0 $
+ *
+ * Last updated: v1.2.2
+ */
+
+namespace PayPalRestful\Admin\Formatters;
+
+class NullMessages
+{
+    public $messages = [];
+    public $errors = [];
+    public $size = 0;
+    private $formats = [];
+
+
+    public function __construct()
+    {
+        // Do nothing. This is a null-object class.
+    }
+
+    public function add($class = '', $message = '', $type = 'error')
+    {
+    }
+
+    public function add_session($class = '', $message = '', $type = 'error')
+    {
+    }
+
+    public function add_from_session()
+    {
+    }
+
+    public function size($key)
+    {
+        return 0;
+    }
+
+    public function clear()
+    {
+    }
+
+    public function reset()
+    {
+    }
+
+    public function output($class = '')
+    {
+        return '';
+    }
+
+    public function getMessages()
+    {
+        return [];
+    }
+
+    public function setMessageFormatting($formattingArray = [])
+    {
+    }
+
+    public function getDefaultFormats()
+    {
+        return [];
+    }
+}
+

--- a/includes/modules/payment/paypal/PayPalRestful/Admin/GetPayPalOrderTransactions.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Admin/GetPayPalOrderTransactions.php
@@ -11,6 +11,7 @@
 namespace PayPalRestful\Admin;
 
 use PayPalRestful\Admin\Formatters\Messages;
+use PayPalRestful\Admin\Formatters\NullMessages;
 use PayPalRestful\Api\PayPalRestfulApi;
 use PayPalRestful\Common\Helpers;
 use PayPalRestful\Common\Logger;
@@ -45,7 +46,14 @@ class GetPayPalOrderTransactions
         $this->ppr = $ppr;
 
         $this->log = new Logger();
-        $this->messages = new Messages();
+
+        if (\IS_ADMIN_FLAG === true) {
+            $this->messages = new Messages();
+        } else {
+            // Use a null-object class to avoid errors where calling messageStack methods
+            // may trigger problems where no messages are actually needed such as webhooks
+            $this->messages = new NullMessages();
+        }
 
         $this->getPayPalDatabaseTransactionsForOrder();
     }


### PR DESCRIPTION
Use null-object pattern to just simulate all the available method calls, but effectively do a no-op since in webhook situations no messageStack output is actually used.

Hopefully is a workable resolution for #81 