### PR TITLE
set header sent in old method

### DIFF
--- a/includes/classes/observers/auto.paypalrestful.php
+++ b/includes/classes/observers/auto.paypalrestful.php
@@ -128,7 +128,7 @@ class zcObserverPaypalrestful extends base
         if ($this->headerAssetsSent) {
             return;
         }
-        $this->outputJsSdkHeaderAssets($current_page_base);
+        $this->headerAssetsSent = $this->outputJsSdkHeaderAssets($current_page_base);
     }
     public function updateNotifyHtmlHeadJsBegin(&$class, $eventID, $current_page_base)
     {


### PR DESCRIPTION
Messaging not displayed when using old method as headerAssestsSent not being set
as [https://www.zen-cart.com/showthread.php/229886-PayPal-RESTful-API-Payment-Module?p=1409410#post1409410](https://www.zen-cart.com/showthread.php/229886-PayPal-RESTful-API-Payment-Module?p=1409410#post1409410)

Ref #111 