### PR TITLE
Sync with zc220+ encapsulated changes

### DIFF
--- a/admin/includes/classes/observers/auto.PaypalRestAdmin.php
+++ b/admin/includes/classes/observers/auto.PaypalRestAdmin.php
@@ -3,14 +3,12 @@
  * Part of the paypalr (PayPal Restful Api) payment module.
  * Admin handles package tracking updates.
  *
- * Last updated: v1.3.0
+ * Last updated: v1.3.2
  */
 
 use PayPalRestful\Api\Data\CountryCodes;
 use PayPalRestful\Api\PayPalRestfulApi;
 use PayPalRestful\Zc2Pp\Amount;
-
-require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
 
 class zcObserverPaypalRestAdmin extends base
 {
@@ -18,6 +16,8 @@ class zcObserverPaypalRestAdmin extends base
 
     public function __construct()
     {
+        require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
+
         // -----
         // If the paypalr payment-module isn't installed or isn't configured to be enabled,
         // then nothing further to do here.

--- a/includes/classes/observers/auto.paypalrestful.php
+++ b/includes/classes/observers/auto.paypalrestful.php
@@ -7,14 +7,12 @@
  * to determine an order's overall value and what amounts each order-total
  * module has added/subtracted to the order's overall value.
  *
- * Last updated: v1.3.1
+ * Last updated: v1.3.2
  */
 
 use PayPalRestful\Api\Data\CountryCodes;
 use PayPalRestful\Api\PayPalRestfulApi;
 use PayPalRestful\Zc2Pp\Amount;
-
-require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
 
 class zcObserverPaypalrestful extends base
 {
@@ -25,6 +23,13 @@ class zcObserverPaypalrestful extends base
 
     public function __construct()
     {
+        // -----
+        // 1. Identify the full file-system name of the 'base' payment module.
+        // 2. Load the payment-module's class auto-loader.
+        //
+        define('FILENAME_PAYPALR_MODULE', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypalr.php');
+        require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
+
         // -----
         // If loaded via ppr_webhook.php, ensure that the $spider_flag is set so
         // that application_top.php doesn't try to load the counter.php module which,

--- a/includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookResponder.php
+++ b/includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookResponder.php
@@ -9,7 +9,7 @@
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte June 2025 $
  *
- * Last updated: v1.3.0
+ * Last updated: v1.3.2
  */
 
 namespace PayPalRestful\Webhooks;
@@ -81,6 +81,15 @@ class WebhookResponder
     {
         $headers = array_change_key_case($this->webhook->getHeaders(), CASE_UPPER);
 
+        if (!isset($headers['PAYPAL-TRANSMISSION-ID'], $headers['PAYPAL-TRANSMISSION-TIME'], $headers['PAYPAL-TRANSMISSION-SIG'], $headers['PAYPAL-CERT-URL'])) {
+            return null; // unable to do CRC check, so we will fail over to PostBack approach
+        }
+        if (empty($this->webhook_listener_subscribe_id)) {
+            return null; // we don't have a webhook listener subscribe ID set, so we will fail over to PostBack approach
+        }
+        if (!function_exists('openssl_verify')) {
+            return null; // OpenSSL functions not available, so we will fail over to PostBack approach
+        }
         $transmissionId = $headers['PAYPAL-TRANSMISSION-ID'];
         $timestamp = $headers['PAYPAL-TRANSMISSION-TIME'];
         $crc = \hexdec(\hash('crc32b', $this->webhook->getRawBody()));
@@ -92,10 +101,23 @@ class WebhookResponder
 
         // @TODO - consider download and cache the public key, from the URL, instead of retrieving fresh in real time
         $pem_cert = $this->read_url($publicKeyUrl);
+        if ($pem_cert === false) {
+            return null; // unable to retrieve cert, so we will fail over to PostBack approach
+        }
 
         $publicKey = openssl_get_publickey($pem_cert);
+        if ($publicKey === false) {
+            // openssl_get_publickey error; we can log this if needed, but for now we will just fail over to PostBack approach
+            //$this->ppr_logger->write('OpenSSL error retrieving public key: ' . openssl_error_string(), false, 'before');
+            return null;
+        }
 
         $result = openssl_verify($calculatedSignature, $decodedSignature, $publicKey, OPENSSL_ALGO_SHA256);
+        if ($result === -1) {
+            // openssl_verify error; we can log this if needed, but for now we will just fail over to PostBack approach
+            //$this->ppr_logger->write('OpenSSL error during webhook CRC check: ' . openssl_error_string(), false, 'before');
+            return null;
+        }
         return $result === 1;
     }
 
@@ -116,7 +138,7 @@ class WebhookResponder
         ];
 
         // Load the PayPal RESTful API class and get the credentials, so we can make the postback using the current access token
-        require DIR_WS_MODULES . 'payment/paypalr.php';
+        require FILENAME_PAYPALR_MODULE;
         list($client_id, $secret) = \paypalr::getEnvironmentInfo();
         $ppr = new PayPalRestfulApi(MODULE_PAYMENT_PAYPALR_SERVER, $client_id, $secret);
 

--- a/includes/modules/payment/paypal/PayPalRestful/ppr_listener.php
+++ b/includes/modules/payment/paypal/PayPalRestful/ppr_listener.php
@@ -7,7 +7,7 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:  $
  *
- * Last updated: v1.3.0
+ * Last updated: v1.3.2
  */
 require 'includes/application_top.php';
 
@@ -20,8 +20,6 @@ if (!defined('MODULE_PAYMENT_PAYPALR_STATUS') || MODULE_PAYMENT_PAYPALR_STATUS =
     require DIR_WS_INCLUDES . 'application_bottom.php';
     die();
 }
-
-require DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
 
 use PayPalRestful\Api\PayPalRestfulApi;
 use PayPalRestful\Common\Logger;
@@ -53,7 +51,7 @@ if (!in_array($op, $valid_operations, true)) {
 //
 if ($op === 'cancel' || $op === '3ds_cancel') {
     unset($_SESSION['PayPalRestful']['Order']['PayerAction']);
-    zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT), '', 'SSL');
+    zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
 }
 
 if ($op === 'return' && (!isset($_GET['token'], $_SESSION['PayPalRestful']['Order']['id']) || $_GET['token'] !== $_SESSION['PayPalRestful']['Order']['id'])) {
@@ -75,7 +73,7 @@ if ($op === 'return' && (!isset($_GET['token'], $_SESSION['PayPalRestful']['Orde
 //
 if (!isset($_SESSION['PayPalRestful']['Order']['PayerAction'])) {
     $logger->write('ppr_listener, redirecting to checkout_payment; no PayerAction variables.', true, 'after');
-    zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT), '', 'SSL');
+    zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
 }
 
 // -----
@@ -83,7 +81,7 @@ if (!isset($_SESSION['PayPalRestful']['Order']['PayerAction'])) {
 // customer's PayPal Wallet selection or the customer has completed
 // a 3DS verification for a credit-card payment.
 //
-require DIR_WS_MODULES . 'payment/paypalr.php';
+require FILENAME_PAYPALR_MODULE;
 list($client_id, $secret) = paypalr::getEnvironmentInfo();
 
 $ppr = new PayPalRestfulApi(MODULE_PAYMENT_PAYPALR_SERVER, $client_id, $secret);
@@ -108,7 +106,7 @@ if ($op === '3ds_return') {
     if ($liability_shift === 'UNKNOWN' || ($enrollment_status === 'Y' && $liability_shift === 'NO')) {
         $messageStack->add_session('checkout_payment', MODULE_PAYMENT_PAYPALR_REDIRECT_LISTENER_TRY_AGAIN, 'error');
         unset($_SESSION['PayPalRestful']['Order']['PayerAction'], $_SESSION['PayPalRestful']['Order']['authentication_result']);
-        zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT), '', 'SSL');
+        zen_redirect(zen_href_link(FILENAME_CHECKOUT_PAYMENT, '', 'SSL'));
     }
 }
 

--- a/includes/modules/payment/paypal/PayPalRestful/ppr_webhook.php
+++ b/includes/modules/payment/paypal/PayPalRestful/ppr_webhook.php
@@ -6,7 +6,7 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: DrByte June 2025 $
  *
- * Last updated: v1.2.0
+ * Last updated: v1.3.2
  *
  * This webhook handler must listen on HTTPS port 443.
  * For webhook message deliveries to be successful, the handler must respond with an HTTP 2xx success status every time a webhook is posted.
@@ -28,7 +28,6 @@
 $loaderPrefix = 'webhook';
 require 'includes/application_top.php';
 $current_page_base = 'ppr_webhook';
-require DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
 
 // call the controller class, which will dispatch as needed, if validation passes
 $controller = new PayPalRestful\Webhooks\WebhookController();

--- a/includes/modules/payment/paypal/pprAutoload.php
+++ b/includes/modules/payment/paypal/pprAutoload.php
@@ -4,19 +4,21 @@
  * @license https://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id:  $
  *
- *  Last updated: v1.2.2
+ *  Last updated: v1.3.2
  *
  */
+$pprautoload_dir = __DIR__ . '/';
+
 global $psr4Autoloader;
 
-$psr4Autoloader->addPrefix('PayPalRestful\Admin', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Admin');
-$psr4Autoloader->addPrefix('PayPalRestful\Admin\Formatters', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Admin/Formatters');
-$psr4Autoloader->addPrefix('PayPalRestful\Api', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Api');
-$psr4Autoloader->addPrefix('PayPalRestful\Api\Data', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Api/Data');
-$psr4Autoloader->addPrefix('PayPalRestful\Common', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Common');
-$psr4Autoloader->addPrefix('PayPalRestful\Token', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Token');
-$psr4Autoloader->addPrefix('PayPalRestful\Webhooks', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Webhooks');
-$psr4Autoloader->addPrefix('PayPalRestful\Zc2Pp', DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/PayPalRestful/Zc2Pp');
+$psr4Autoloader->addPrefix('PayPalRestful\Admin', $pprautoload_dir . 'PayPalRestful/Admin');
+$psr4Autoloader->addPrefix('PayPalRestful\Admin\Formatters', $pprautoload_dir . 'PayPalRestful/Admin/Formatters');
+$psr4Autoloader->addPrefix('PayPalRestful\Api', $pprautoload_dir . 'PayPalRestful/Api');
+$psr4Autoloader->addPrefix('PayPalRestful\Api\Data', $pprautoload_dir . 'PayPalRestful/Api/Data');
+$psr4Autoloader->addPrefix('PayPalRestful\Common', $pprautoload_dir . 'PayPalRestful/Common');
+$psr4Autoloader->addPrefix('PayPalRestful\Token', $pprautoload_dir . 'PayPalRestful/Token');
+$psr4Autoloader->addPrefix('PayPalRestful\Webhooks', $pprautoload_dir . 'PayPalRestful/Webhooks');
+$psr4Autoloader->addPrefix('PayPalRestful\Zc2Pp', $pprautoload_dir . 'PayPalRestful/Zc2Pp');
 
 // -----
 // The zcDate class was introduced in zc158. If the

--- a/includes/modules/payment/paypalr.php
+++ b/includes/modules/payment/paypalr.php
@@ -8,11 +8,6 @@
  *
  * Last updated: v1.3.2
  */
-/**
- * Load the support class' auto-loader.
- */
-require_once DIR_FS_CATALOG . DIR_WS_MODULES . 'payment/paypal/pprAutoload.php';
-
 use PayPalRestful\Admin\AdminMain;
 use PayPalRestful\Admin\DoAuthorization;
 use PayPalRestful\Admin\DoCapture;

--- a/readme_paypalr.html
+++ b/readme_paypalr.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>PayPal Restful Payment Module for Zen Cart 1.5.8a and Later</title>
+<title>PayPal Restful Payment Module for Zen Cart 1.5.8a through 2.1.0</title>
 <style>
 a, a:active,
 a:visited {
@@ -90,7 +90,7 @@ table table {
 </head>
 
 <body>
-    <h1>PayPal RESTful Payment Module (<var>paypalr</var>) for Zen Cart 1.5.8a and later</h1>
+    <h1>PayPal RESTful Payment Module (<var>paypalr</var>) for Zen Cart 1.5.8a through 2.1.0</h1>
     <h3>Version 1.3.2</h3>
     <p>Current Support Thread at Zen Cart Forums: <a href="https://www.zen-cart.com/showthread.php/229886-PayPal-RESTful-API-Payment-Module" target="_blank">https://www.zen-cart.com/showthread.php/229886-PayPal-RESTful-API-Payment-Module</a></p>
     <p>Zen Cart Download Link: <a href="https://www.zen-cart.com/downloads.php?do=file&id=2382" target="_blank">https://www.zen-cart.com/downloads.php?do=file&id=2382</a></p>
@@ -203,9 +203,16 @@ table table {
     <ul>
         <li>v1.3.2-beta1, 2026-03-20 (lat9,)<ul>
             <li>BUGFIX: Restore zcDate instantiation during webhook processing to correct fatal PHP errors.</li>
+            <li>INTROP: Align with updates from the encapsulated version included in Zen Cart 2.2.0 and later.</li>
             <li>The following files were changed:<ol>
                 <li>/includes/auto_loaders/webhook.core.php</li>
+                <li>/includes/classes/observers/auto.paypalrestful.php</li>
                 <li>/includes/modules/payment/paypalr.php</li>
+                <li>/includes/modules/payment/paypal/pprAutoload.php</li>
+                <li>/includes/modules/payment/paypal/PayPalRestful/ppr_listener.php</li>
+                <li>/includes/modules/payment/paypal/PayPalRestful/ppr_webhook.php</li>
+                <li>/includes/modules/payment/paypal/PayPalRestful/Webhooks/WebhookResponder.php</li>
+                <li>/YOUR_ADMIN/includes/classes/observers/auto.PaypalRestAdmin.php</li>
             </ol></li>
         </ul></li>
         <li>v1.3.1, 2026-03-11 (lat9, brittainmark, andy-1977)<ul>


### PR DESCRIPTION
- pprAutoload.php is now loaded via the admin/catalog observers.
- PHP define created in the catalog observer pointing to the 'base' payment module.
- Correct misplaced parens on zen_redirect calls in `ppr_listener.php`.
- Update WebhookResponder `doCrcCheck` to return `null` if posted results are necessary.