### PR TITLE
Update jquery.paypalr.jssdk_messages.js - Fix Wrong Amounts In Pay Later Message On Product Pages

### DIFF
--- a/includes/modules/payment/paypal/PayPalRestful/jquery.paypalr.jssdk_messages.js
+++ b/includes/modules/payment/paypal/PayPalRestful/jquery.paypalr.jssdk_messages.js
@@ -71,31 +71,29 @@ jQuery(function() {
                 return true;
             }
 
-            // First, use .replace to remove characters other than
-            // numerics and comma/period separators (e.g. currency symbols).
+            // Extract numeric price from the element text (strip currency symbols, etc.)
             let price = priceElement.textContent.replace(/[^\d.,]/g, '');
 
-            // Next, split the price value into its 2-digit decimal digits (at
-            // the end of string) and its integral portion (to the left of the
-            // decimal point (either a period or comma).
-            //
-            // There "should be" 3 pieces (entire string, integral portion and decimal portion)
-            // returned by the match; if not, cycle to the next price
-            let pieces = price.match(/^([\d.,]+)[.,](\d{2})$/);
-            console.info('Msgs Loop ' + index + ': Price ' + price + ', Pieces: ' + pieces);
-            if (pieces.length !== 3) {
-                return true;
+            // Clean whitespace
+            price = price.trim();
+
+            // Convert to float safely
+            let numericPrice = parseFloat(
+            price.replace(/,/g, '') // remove thousands separators
+            );
+
+            // If invalid, skip
+            if (isNaN(numericPrice)) {
+            console.warn('Invalid price detected:', price);
+            return true;
             }
 
-            // Finally, form the price to be sent to PayPal, removing any '.,' characters
-            // from the integral value and using a period as the decimal separator.
-            price = pieces[1].replace(/[.,]/g, '')+'.'+pieces[2];
-            console.info('Reformatted price: '+price);
+            // Format to PayPal-required string (2 decimal places, dot separator)
+            price = numericPrice.toFixed(2);
 
+            // Apply attributes for PayPal messaging
             $addTo = $findInContainer.length > 1 ? jQuery(element) : $output;
 
-            // The PayPal SDK monitors message elements for changes to its attributes such as data-pp-amount, which we add here,
-            // so their messaging is updated automatically to reflect this amount in whatever messaging PayPal displays.
             $addTo.attr('data-pp-amount', price);
             $addTo.attr('data-pp-currency', paypalPayLaterCurrency);
         });

--- a/includes/modules/payment/paypal/PayPalRestful/jquery.paypalr.jssdk_messages.js
+++ b/includes/modules/payment/paypal/PayPalRestful/jquery.paypalr.jssdk_messages.js
@@ -72,15 +72,26 @@ jQuery(function() {
             }
 
             // Extract numeric price from the element text (strip currency symbols, etc.)
-            let price = priceElement.textContent.replace(/[^\d.,]/g, '');
+            let price = priceElement.textContent.replace(/[^\d.,]/g, '').trim();
 
-            // Clean whitespace
-            price = price.trim();
+            // Detect decimal separator (last occurrence of . or ,)
+            let lastDot = price.lastIndexOf('.');
+            let lastComma = price.lastIndexOf(',');
 
-            // Convert to float safely
-            let numericPrice = parseFloat(
-            price.replace(/,/g, '') // remove thousands separators
-            );
+            let normalized;
+
+            // If comma is the decimal separator (e.g. 2,18 or 1.234,56)
+            if (lastComma > lastDot) {
+            normalized = price
+            .replace(/\./g, '')  // remove thousands separators
+            .replace(',', '.');  // convert decimal to dot
+            } else {
+            // Dot is decimal separator (e.g. 2.18 or 1,234.56)
+            normalized = price
+           .replace(/,/g, '');   // remove thousands separators
+            }
+
+            let numericPrice = parseFloat(normalized);
 
             // If invalid, skip
             if (isNaN(numericPrice)) {
@@ -88,7 +99,7 @@ jQuery(function() {
             return true;
             }
 
-            // Format to PayPal-required string (2 decimal places, dot separator)
+            // Format to PayPal-required string
             price = numericPrice.toFixed(2);
 
             // Apply attributes for PayPal messaging

--- a/includes/modules/payment/paypal/PayPalRestful/jquery.paypalr.jssdk_messages.js
+++ b/includes/modules/payment/paypal/PayPalRestful/jquery.paypalr.jssdk_messages.js
@@ -1,5 +1,5 @@
 // PayPal PayLater messaging
-// Last updated: v1.3.1
+// Last updated: v1.3.2
 if (!paypalMessagesPageType.length) {
     paypalMessagesPageType = "None";
 }
@@ -82,21 +82,21 @@ jQuery(function() {
 
             // If comma is the decimal separator (e.g. 2,18 or 1.234,56)
             if (lastComma > lastDot) {
-            normalized = price
-            .replace(/\./g, '')  // remove thousands separators
-            .replace(',', '.');  // convert decimal to dot
+                normalized = price
+                    .replace(/\./g, '')  // remove thousands separators
+                    .replace(',', '.');  // convert decimal to dot
             } else {
-            // Dot is decimal separator (e.g. 2.18 or 1,234.56)
-            normalized = price
-           .replace(/,/g, '');   // remove thousands separators
+                // Dot is decimal separator (e.g. 2.18 or 1,234.56)
+                normalized = price
+                   .replace(/,/g, '');   // remove thousands separators
             }
 
             let numericPrice = parseFloat(normalized);
 
             // If invalid, skip
             if (isNaN(numericPrice)) {
-            console.warn('Invalid price detected:', price);
-            return true;
+                console.warn('Invalid price detected:', price);
+                return true;
             }
 
             // Format to PayPal-required string

--- a/includes/modules/payment/paypal/PayPalRestful/jquery.paypalr.jssdk_messages.js
+++ b/includes/modules/payment/paypal/PayPalRestful/jquery.paypalr.jssdk_messages.js
@@ -1,5 +1,5 @@
 // PayPal PayLater messaging
-// Last updated: v1.3.2
+// Last updated: v2.0.1/1.3.2
 if (!paypalMessagesPageType.length) {
     paypalMessagesPageType = "None";
 }
@@ -83,12 +83,12 @@ jQuery(function() {
             // If comma is the decimal separator (e.g. 2,18 or 1.234,56)
             if (lastComma > lastDot) {
                 normalized = price
-                    .replace(/\./g, '')  // remove thousands separators
-                    .replace(',', '.');  // convert decimal to dot
+                  .replace(/\./g, '')  // remove thousands separators
+                  .replace(',', '.');  // convert decimal to dot
             } else {
                 // Dot is decimal separator (e.g. 2.18 or 1,234.56)
-                normalized = price
-                   .replace(/,/g, '');   // remove thousands separators
+                // remove thousands separators
+                normalized = price.replace(/,/g, '');
             }
 
             let numericPrice = parseFloat(normalized);
@@ -105,6 +105,8 @@ jQuery(function() {
             // Apply attributes for PayPal messaging
             $addTo = $findInContainer.length > 1 ? jQuery(element) : $output;
 
+            // The PayPal SDK monitors message elements for changes to its attributes such as data-pp-amount, which we add here,
+            // so their messaging is updated automatically to reflect this amount in whatever messaging PayPal displays.
             $addTo.attr('data-pp-amount', price);
             $addTo.attr('data-pp-currency', paypalPayLaterCurrency);
         });


### PR DESCRIPTION
Ref #118 

Fix wrong amounts showing on product pages for small amounts e.g: £2.18, shows as the following:

Split your purchase of £2,182.62 into 3 with no sign-up fees or late fees.

This change fixes this issue.

https://github.com/andy-1977/paypalr/commit/4b071ac0039076bad49439a697dd538d750e1f03